### PR TITLE
GROUPS_ARE_AUTHORITATIVE setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ SHIBBOLETH_SESSION_AUTH = {
     'GROUP_ATTRIBUTE': 'member',
     'GROUPS_BY_IDP': {},
     'DJANGO_STAFF_GROUP': 'webadmin',
+    ‘GROUPS_ARE_AUTHORITATIVE’: True,
 }
 ```
 
@@ -89,9 +90,13 @@ the user will be added to each of the groups, creating the groups as necessary.
 `DJANGO_STAFF_GROUP` is the name of the group presented by the IdP that will
 be used to determine if the user has the `is_staff` bit set or not.
 
-We assume the the IdP is the source of truth for groups and for whether or not
-a user should have Django staff privileges. This means that the set of groups
-the user will be a member of will be exactly the set of groups that the IdP
-sends. This also means that if the user is no longer a member of
-`DJANGO_STAFF_GROUP` that they will lose their staff privileges.
+If `GROUPS_ARE_AUTHORITATIVE` is true (or not set), we assume the the
+IdP is the source of truth for groups and for whether or not a user
+should have Django staff privileges. This means that the set of groups
+the user will be a member of will be exactly the set of groups that
+the IdP sends. This also means that if the user is no longer a member
+of `DJANGO_STAFF_GROUP` that they will lose their staff privileges.
 
+If `GROUPS_ARE_AUTHORITATIVE` is false, we add groups as specified by
+`GROUP_ATTRIBUTE` and `GROUPS_BY_IDP`, but never remove groups or
+alter the is_staff attribute of a user.

--- a/shibboleth_session_auth/views.py
+++ b/shibboleth_session_auth/views.py
@@ -71,17 +71,18 @@ def shibboleth_session_auth(request):
                 group.user_set.add(user)
                 logger.info("adding user %s to group %s", user.username, group.name)
 
-    user_groups = user.groups.all()
-    for group in user_groups:
-        if group.name not in idp_provided_group_names:
-            group.user_set.remove(user)
+    if settings.SHIBBOLETH_SESSION_AUTH.get('GROUPS_ARE_AUTHORITATIVE', True):
+        user_groups = user.groups.all()
+        for group in user_groups:
+            if group.name not in idp_provided_group_names:
+                group.user_set.remove(user)
 
-    staff_group_name = settings.SHIBBOLETH_SESSION_AUTH['DJANGO_STAFF_GROUP']
-    if staff_group_name:
-        is_staff_group_member = user.groups.filter(name=staff_group_name).count() > 0
-        if user.is_staff != is_staff_group_member:
-            user.is_staff = is_staff_group_member
-            user.save()
+        staff_group_name = settings.SHIBBOLETH_SESSION_AUTH['DJANGO_STAFF_GROUP']
+        if staff_group_name:
+            is_staff_group_member = user.groups.filter(name=staff_group_name).count() > 0
+            if user.is_staff != is_staff_group_member:
+                user.is_staff = is_staff_group_member
+                user.save()
 
     user = authenticate(remote_user=user.username)
     login(request, user)


### PR DESCRIPTION
This is just a  simple tweak that makes the removing of groups and altering of is_staff optional. The default behavior remains the same.